### PR TITLE
add ability to handle overlapping shifts

### DIFF
--- a/shifts/models.py
+++ b/shifts/models.py
@@ -1,5 +1,8 @@
+import datetime
+
 from django.db import models
 from django.conf import settings
+
 from departments.models import Department
 
 
@@ -8,3 +11,14 @@ class Shift(models.Model):
     start_time = models.DateTimeField('shift begins')
     shift_length = models.PositiveSmallIntegerField(default=3)
     owner = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True, related_name='shifts')
+
+    @property
+    def end_time(self):
+        return self.start_time + datetime.timedelta(hours=self.shift_length)
+
+    def overlaps_with(self, other):
+        if self.end_time <= other.start_time:
+            return False
+        elif self.start_time >= other.end_time:
+            return False
+        return True

--- a/shifts/templates/shifts/shifts.html
+++ b/shifts/templates/shifts/shifts.html
@@ -35,7 +35,10 @@
                             {% for row in length.list %}
                                 {% for cell in row.tabular %}
                                 <td class="{{ cell.class }}" colspan="{{ cell.columns }}">
-                                    {% if cell.id > 0 %} 
+                                    {% if cell.has_many %}
+                                        <p>This cell has many cells, deal with it</p>
+                                        {# TODO: many cells in one cell #}
+                                    {% elif cell.id %} 
                                         {% if cell.owner %}
                                             <a class="claimed-shift" href="/shifts/release/{{ cell.id }}" alt="{{ cell.owner }} @ {{ cell.start_at }}" title="{{ cell.owner }} @ {{ cell.start_at }}">{{ shift.owner|stringformat:"s"|slice:":6" }}..</a>
                                         {% else %}

--- a/shifts/views.py
+++ b/shifts/views.py
@@ -1,4 +1,4 @@
-from django.views.generic import TemplateView, DetailView
+from django.views.generic import TemplateView, DetailView, ListView
 from departments.models import Department
 from shifts.models import Shift
 from shifts.utils import group_shifts, shifts_to_tabular_data
@@ -34,20 +34,18 @@ class ReleaseView(DetailView):
         return shift
 
 
-#shift this have been a list view? should I be using group by?
-class GridView(TemplateView):
+class GridView(ListView):
     template_name = "shifts/shifts.html"
+    model = Shift
+
+    def get_queryset(self):
+        qs = super(GridView, self).get_queryset()
+        return qs.select_related()
 
     def get_context_data(self, **kwargs):
         context = super(GridView, self).get_context_data(**kwargs)
 
-        #it may not even matter that we're sorting here
-        shifts = Shift.objects.order_by(
-            'start_time',
-            'department',
-            'shift_length'
-        )
-        context['grouped_shifts'] = group_shifts(shifts)
+        context['grouped_shifts'] = list(group_shifts(self.object_list))
         return context
 
     def extract_date(entity):


### PR DESCRIPTION
### What is the problem / feature ?
- There was a bug in our shift grouping that made overlapping shifts get organized next to each other.
- There was no support for overlapping shifts.
### How did it get fixed / implemented ?
- Added support for overlapping shifts
### How can someone test / see it ?

Create some overlapping shifts and see that the interface is ready for koda to make them look nice.

_Here is a cute baby animal picture for your troubles..._

![sxc_chicks](https://f.cloud.github.com/assets/824194/2375285/042b8594-a86a-11e3-87ee-11f15c6d0862.jpg)
