### PR TITLE
Add password reset functionality

### DIFF
--- a/accounts/templates/accounts/profile.html
+++ b/accounts/templates/accounts/profile.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block body_class %}{{ block.super }} home{% endblock %}
+
+{% block content %}
+    <!-- Add your site or application content here -->
+    <h1>Profile</h1>
+    <section>
+      <p>
+          Blah Blah Blah
+      </p>
+    </section>
+{% endblock %}

--- a/accounts/templates/registration/login.html
+++ b/accounts/templates/registration/login.html
@@ -10,6 +10,7 @@
 
 {{ form }}
 <input type="submit" />
+<a href="{% url 'password_reset' %}">Forgot Password?</a>
 </form>
 
 	</section>

--- a/accounts/templates/registration/password_reset_confirm.html
+++ b/accounts/templates/registration/password_reset_confirm.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block body_class %}{{ block.super }} home{% endblock %}
+
+{% block content %}
+    <!-- Add your site or application content here -->
+    <h1><span>Password Reset</span></h1>
+    <section>
+        {% if validlink %}
+            <p>
+                Fill in the following form to reset your password.
+            </p>
+
+            <form action="{{ request.path }}" method="post">
+                {% include 'partials/form_as_fieldsets.html' %}
+                <input type="submit" />
+            </form>
+        {% else %}
+            <p>
+                Invalid link.
+            </p>
+        {% endif %}
+    </section>
+{% endblock %}

--- a/accounts/templates/registration/password_reset_done.html
+++ b/accounts/templates/registration/password_reset_done.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block body_class %}{{ block.super }} home{% endblock %}
+
+{% block content %}
+    <!-- Add your site or application content here -->
+    <h1><span>Password Reset Email Sent</span></h1>
+    <section>
+        <p>
+            An email containing a link to reset your password has been sent to
+            your inbox.
+        </p>
+    </section>
+{% endblock %}

--- a/accounts/templates/registration/password_reset_form.html
+++ b/accounts/templates/registration/password_reset_form.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block body_class %}{{ block.super }} home{% endblock %}
+
+{% block content %}
+    <!-- Add your site or application content here -->
+    <h1><span>Password Reset</span></h1>
+    <section>
+        <p>
+            Forgotten your password? Enter your email address below, and we'll
+            email instructions for setting a new one.
+        </p>
+
+        <form action="{% url 'password_reset' %}" method="post">
+            {% include 'partials/form_as_fieldsets.html' %}
+            <input type="submit" />
+        </form>
+    </section>
+{% endblock %}

--- a/accounts/templates/registration/register_confirm.html
+++ b/accounts/templates/registration/register_confirm.html
@@ -19,7 +19,7 @@
           <p>To complete your registration for <b>{{ email }}</b> please complete
           the form below</p>
 
-          <form action="{% url 'register-confirm' token=token %}" method="post">{% csrf_token %}
+          <form action="{% url 'register_confirm' token=token %}" method="post">{% csrf_token %}
               {% include 'partials/form_as_fieldsets.html' %}
               <input type="submit" />
           </form>

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -111,7 +111,7 @@ class RegistrationTest(TestCase):
         self.assertTrue(post_response.context['signature_expired'])
 
     def test_registration_confirmation_page_with_bad_token(self):
-        url = reverse('register-confirm', kwargs={'token': 'BADTOKEN'})
+        url = reverse('register_confirm', kwargs={'token': 'BADTOKEN'})
         get_response = self.client.get(url)
         self.assertContains(get_response, '', status_code=status.HTTP_200_OK)
         self.assertTrue(get_response.context['bad_signature'])

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,36 +1,38 @@
 from django.conf.urls import patterns, url
 from accounts.views import (
-    RegisterView, RegisterSuccessView, RegisterConfirmView,
+    RegisterView, RegisterSuccessView, RegisterConfirmView, ProfileView,
 )
 
 
 urlpatterns = patterns('',  # NOQA
+    url(r'^/$', ProfileView.as_view(), name='profile'),
     url(r'^register/$', RegisterView.as_view(), name='register'),
     url(
         r'^register/success/$', RegisterSuccessView.as_view(),
-        name='register-success',
+        name='register_success',
     ),
     url(
         r'^register/(?P<token>[-a-zA-Z0-9_:]+)/$',
         RegisterConfirmView.as_view(),
-        name='register-confirm',
+        name='register_confirm',
     ),
 )
 urlpatterns += patterns(
     'authtools.views',
     url(r'^login/$', 'login', name='login'),
     url(r'^logout/$', 'logout_then_login', name='logout'),
-    url(r'^password-reset/$', 'password_reset', name='password-reset'),
+    url(r'^password-reset/$', 'password_reset', name='password_reset'),
     url(
         r'^password-reset-done/$', 'password_reset_done',
-        name='password-reset-done',
+        name='password_reset_done',
     ),
     url(
-        r'^password-reset-confirm/(?P<uidb36>\w+)/(?P<token>[-a-zA-Z0-9]+)/$',
-        'password_reset_confirm_and_login', name='password-reset-confirm',
+        r'^reset/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
+        'password_reset_confirm_and_login',
+        name='password_reset_confirm',
     ),
     url(
         r'^password-reset-complete/$', 'password_reset_complete',
-        name='password-reset-complete',
+        name='password_reset_complete',
     ),
 )

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -13,7 +13,7 @@ def generate_registration_token(email):
 def reverse_registration_url(email):
     validate_email(email)
     token = generate_registration_token(email)
-    return reverse('register-confirm', kwargs={'token': token})
+    return reverse('register_confirm', kwargs={'token': token})
 
 
 def unsign_registration_token(token):

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,10 +1,14 @@
 from django.core import signing
-from django.views.generic import FormView, CreateView, TemplateView
+from django.views.generic import (
+    FormView, CreateView, TemplateView, DetailView,
+)
 from django.core.urlresolvers import reverse_lazy
 from django.shortcuts import redirect
 from django.contrib.auth import get_user_model, login as auth_login, authenticate
 
 User = get_user_model()
+
+from authtools.views import LoginRequiredMixin
 
 from accounts.forms import (
     UserRegistrationForm, UserRegistrationConfirmForm,
@@ -16,7 +20,7 @@ from accounts.utils import unsign_registration_token
 class RegisterView(FormView):
     template_name = 'registration/register.html'
     form_class = UserRegistrationForm
-    success_url = reverse_lazy('register-success')
+    success_url = reverse_lazy('register_success')
 
     def form_valid(self, form):
         send_registration_verification_email(form.data['email'])
@@ -69,3 +73,10 @@ class RegisterConfirmView(CreateView):
         )
         auth_login(self.request, user)
         return redirect(self.success_url)
+
+
+class ProfileView(LoginRequiredMixin, DetailView):
+    template_name = 'accounts/profile.html'
+
+    def get_object(self):
+        return self.request.user

--- a/volunteer/settings.py
+++ b/volunteer/settings.py
@@ -30,7 +30,6 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = (
-    'django.contrib.admin.apps.AdminConfig',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
@@ -48,6 +47,8 @@ INSTALLED_APPS = (
     'departments',
     'shifts',
     'accounts',
+    # django admin
+    'django.contrib.admin.apps.AdminConfig',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -62,6 +63,8 @@ MIDDLEWARE_CLASSES = (
 ROOT_URLCONF = 'volunteer.urls'
 
 WSGI_APPLICATION = 'volunteer.wsgi.application'
+
+LOGIN_REDIRECT_URL = 'profile'
 
 
 # Database


### PR DESCRIPTION
### What is the problem / feature ?

There was no way to reset your password if you forgot it.
### How did it get fixed / implemented ?

Implemented the views provided by `django-authtools` for password reset.
### How can someone test / see it ?

Go to `/accounts/password-reset/` and follow the password reset flow.

_Here is a cute baby animal picture for your troubles..._

![29364-fawn-pug-pup-8-weeks-old-and-sooty-colourpoint-rabbit-white-background](https://f.cloud.github.com/assets/824194/2385352/768b87d0-a91c-11e3-9b60-e1a74d09665e.jpg)
