### PR TITLE
Add support for overlapping shifts

### DIFF
--- a/shifts/templates/shifts/shifts.html
+++ b/shifts/templates/shifts/shifts.html
@@ -31,24 +31,20 @@
                             <th>6p</th><th>7p</th><th>8p</th>
                             <th>9p</th><th>10p</th><th>11p</th>
                         </tr>
-                        <tr>
-                            {% for row in length.list %}
+                        {% for row in length.list %}
+                            <tr>
                                 {% for cell in row.tabular %}
-                                <td class="{{ cell.class }}" colspan="{{ cell.columns }}">
-                                    {% if cell.has_shifts %}
-                                        {% for shift in cell.shifts %}
-                                            {% if shift.owner %}
-                                                <span><a class="claimed-shift" href="/shifts/release/{{ shift.id }}" alt="{{ shift.owner }} @ {{ shift.start_at }}" title="{{ shift.owner }} @ {{ shift.start_at }}">{{ shift.owner|stringformat:"s"|slice:":6" }}..</a></span>
-                                            {% else %}
-                                                <span><a class="open-shift" href="/shifts/claim/{{ shift.id }}" alt="{{ shift.start_at }}" title="{{ shift.start_at }}">o p e n</a></span>
-                                            {% endif %}                                        
-                                        {% endfor %}                                    
-                                    {% endif %}
-                                </td>
+                                    <td class="{{ cell.class }}" colspan="{{ cell.columns }}">
+                                        {% if cell.shift.owner %}
+                                            <span><a class="claimed-shift" href="/shifts/release/{{ shift.id }}" alt="{{ shift.owner }} @ {{ shift.start_at }}" title="{{ shift.owner }} @ {{ shift.start_at }}">{{ shift.owner|stringformat:"s"|slice:":6" }}..</a></span>
+                                        {% elif cell.shift %}
+                                            <span><a class="open-shift" href="/shifts/claim/{{ shift.id }}" alt="{{ shift.start_at }}" title="{{ shift.start_at }}">o p e n</a></span>
+                                        {% endif %}                                        
+                                    </td>
                                 {% endfor %}
-                            {% endfor %}
 
-                        </tr>
+                            </tr>
+                        {% endfor %}
                         <tr class="bottom"><th colspan="24"></th></tr>
                     </table>
                 {% endfor %}


### PR DESCRIPTION
### What is the problem / feature ?

Overlapping shifts weren't displaying correctly.
### How did it get fixed / implemented ?

Added a sorting algorithm to sort them onto separate lines in a nice way.

http://cl.ly/image/2J3s2G340K24
### How can someone test / see it ?

Create some overlapping shifts and see that they end up on separate lines.

_Here is a cute baby animal picture for your troubles..._

![2tyl7ag](https://f.cloud.github.com/assets/824194/2435947/923ab8a6-add2-11e3-9ec4-4561fec25cb4.jpg)
