### PR TITLE
Add environment configurable emails settings

### DIFF
--- a/volunteer/settings.py
+++ b/volunteer/settings.py
@@ -121,6 +121,11 @@ EMAIL_BACKEND = os.environ.get(
     'DJANGO_EMAIL_BACKEND',
     'django.core.mail.backends.smtp.EmailBackend',
 )
+EMAIL_HOST = os.environ.get('EMAIL_HOST', 'localhost')
+EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER', '')
+EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD', '')
+EMAIL_PORT = os.environ.get('EMAIL_PORT', '25')
+EMAIL_USE_TLS = os.environ.get('EMAIL_USE_TLS') == 'True'
 
 # `django.contrib.sites` settings
 SITE_ID = 1


### PR DESCRIPTION
### What is the problem / feature ?

Configuring django's email settings were not exposed via environment variable configuration
### How did it get fixed / implemented ?

Added some code to pull email settings out of the environment
### How can someone test / see it ?

Code?

_Here is a cute baby animal picture for your troubles..._

![popcorn_the_ferret_04-600x400](https://f.cloud.github.com/assets/824194/2511894/46ba929e-b420-11e3-8250-b31c3592365d.jpg)
