### PR TITLE
force ssl on herkou

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pylibmc==1.2.3
 gunicorn==18.0
 psycopg2==2.5.2
 djangorestframework==2.3.13
+django-sslify==0.2.3

--- a/volunteer/settings_heroku.py
+++ b/volunteer/settings_heroku.py
@@ -16,3 +16,9 @@ CACHES = herokuify.get_cache_config()
 
 DEBUG = os.environ.get('DJANGO_DEBUG') == 'True'
 TEMPLATE_DEBUG = DEBUG
+
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+MIDDLEWARE_CLASSES = (
+    'sslify.middleware.SSLifyMiddleware',
+) + MIDDLEWARE_CLASSES


### PR DESCRIPTION
### What is the problem / feature ?

The app didn't force https while running on heroku.
### How did it get fixed / implemented ?

https://stackoverflow.com/questions/8436666/how-to-make-python-on-heroku-https-only
### How can someone test / see it ?

Navigate to the non https version and see you are redirected.

http://voldb.herokuapp.com/

_Here is a cute baby animal picture for your troubles..._

![st _bernard_puppy](https://cloud.githubusercontent.com/assets/824194/2546494/080f073a-b639-11e3-8105-8023071fa658.jpg)
