### PR TITLE
Piper/track shift history

### DIFF
--- a/shifts/migrations/0007_shifthistory.py
+++ b/shifts/migrations/0007_shifthistory.py
@@ -1,0 +1,28 @@
+# encoding: utf8
+from django.db import models, migrations
+import django.utils.timezone
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('shifts', '0006_shift_code'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ShiftHistory',
+            fields=[
+                (u'id', models.AutoField(verbose_name=u'ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created_at', models.DateTimeField(default=django.utils.timezone.now)),
+                ('shift', models.ForeignKey(to='shifts.Shift', to_field=u'id')),
+                ('action', models.CharField(max_length=10, choices=[(u'claim', u'Claim'), (u'release', u'Release')])),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, to_field=u'id')),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/shifts/tests/test_tracking.py
+++ b/shifts/tests/test_tracking.py
@@ -1,0 +1,47 @@
+from django.test import TestCase
+
+from accounts.factories import UserFactory
+
+from shifts.models import ShiftHistory
+from shifts.factories import ShiftFactory
+
+
+class TrackingTest(TestCase):
+    def test_tracking_only_on_change(self):
+        shift = ShiftFactory(owner=UserFactory())
+
+        self.assertFalse(ShiftHistory.objects.exists())
+
+        shift.save()
+
+        self.assertFalse(ShiftHistory.objects.exists())
+
+    def test_tracking_occurs_on_release(self):
+        user = UserFactory()
+        shift = ShiftFactory(owner=user)
+
+        self.assertFalse(ShiftHistory.objects.exists())
+
+        shift.owner = None
+        shift.save()
+
+        self.assertTrue(ShiftHistory.objects.exists())
+
+        entry = shift.history.get()
+        self.assertEqual(entry.user, user)
+        self.assertEqual(entry.action, ShiftHistory.ACTION_RELEASE)
+
+    def test_tracking_occurs_on_claim(self):
+        user = UserFactory()
+        shift = ShiftFactory()
+
+        self.assertFalse(ShiftHistory.objects.exists())
+
+        shift.owner = user
+        shift.save()
+
+        self.assertTrue(ShiftHistory.objects.exists())
+
+        entry = shift.history.get()
+        self.assertEqual(entry.user, user)
+        self.assertEqual(entry.action, ShiftHistory.ACTION_CLAIM)


### PR DESCRIPTION
### What is the problem / feature ?

Wanted a nice way to track the history of a shift being claimed and/or released.
### How did it get fixed / implemented ?

Added a new model `ShiftHistory` which listens to the `pre_save` signal on shifts and tracks any changes that occur.
### How can someone test / see it ?

There is no interface for this so you'd have to look in the database.

_Here is a cute baby animal picture for your troubles..._

![polar-bears-little-cute-animal-album-701047](https://cloud.githubusercontent.com/assets/824194/2557423/a6cb8416-b701-11e3-9df7-9233fd68d91a.jpg)
