### PR TITLE
added ability to clear codes in bulk

### DIFF
--- a/shifts/admin.py
+++ b/shifts/admin.py
@@ -6,7 +6,7 @@ class ShiftAdmin(admin.ModelAdmin):
     list_display = ('id', 'department', 'start_time', 'shift_length', 'owner', 'code')
     list_filter = ['shift_length', 'department', 'code', 'start_time']
     actions = ['clear_code']
-    
+
     def clear_code(self, request, queryset):
         rows_updated = queryset.update(code='')
         if rows_updated == 1:
@@ -15,6 +15,5 @@ class ShiftAdmin(admin.ModelAdmin):
             message_bit = "%s codes were" % rows_updated
         self.message_user(request, "%s cleared." % message_bit)
     clear_code.short_description = "Clear codes for selected shifts"
-
 
 admin.site.register(Shift, ShiftAdmin)


### PR DESCRIPTION
### What is the problem / feature ?

I accidentally set all blank codes to "None" instead of a blank string. There are hundreds and it would take forever to fix them one by one.
### How did it get fixed / implemented ?

I modified the admin to allow for bulk clearing of codes.
### How can someone test / see it ?

Go into the shifts admin and drop down the action selector.

![2787](https://cloud.githubusercontent.com/assets/611731/2557820/adc38d48-b71c-11e3-9dae-cd96d07090ef.jpg)
