### PR TITLE
Normalize email address during registration

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -11,11 +11,12 @@ from profiles.models import Profile
 class UserRegistrationForm(BetterForm):
     email = forms.EmailField()
 
-    def validate_email(self, value):
+    def clean_email(self):
+        email = self.cleaned_data['email'].lower()
         try:
-            User.objects.get(email__iexact=value)
+            User.objects.get(email__iexact=email)
         except User.DoesNotExist:
-            return value
+            return email
         else:
             raise forms.ValidationError(
                 'An account with that email address already exists',

--- a/accounts/migrations/0002_auto_20140408_1614.py
+++ b/accounts/migrations/0002_auto_20140408_1614.py
@@ -1,0 +1,30 @@
+# encoding: utf8
+from django.db import models, migrations
+
+
+def normalize_email_addresses(apps, schema_editor):
+    # We can't import the Person model directly as it may be a newer
+    # version than this migration expects. We use the historical version.
+    User = apps.get_model("accounts", "User")
+    dupes = set()
+    for user in User.objects.order_by('date_joined'):
+        if user.pk in dupes:
+            continue
+        email = user.email.lower()
+        dupes.update(User.objects.filter(
+            email__iexact=email,
+        ).exclude(pk=user.pk).values_list('pk', flat=True))
+
+    print 'Deleting users {0}'.format(str(dupes))
+    User.objects.filter(pk__in=dupes).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounts', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(normalize_email_addresses),
+    ]

--- a/accounts/tests/test_forms.py
+++ b/accounts/tests/test_forms.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+
+from accounts.forms import UserRegistrationForm
+from accounts.factories import UserFactory
+
+
+class RegistrationFormTest(TestCase):
+    def test_enforces_email_uniqueness(self):
+        user = UserFactory(email='test@example.com')
+
+        form = UserRegistrationForm({'email': user.email})
+
+        self.assertFalse(form.is_valid())
+        self.assertIn('email', form.errors)
+
+    def test_email_normalized(self):
+        upper_email = 'TEST@EXAMPLE.COM'
+        lower_email = 'test@example.com'
+
+        form = UserRegistrationForm({'email': upper_email})
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['email'], lower_email)

--- a/accounts/tests/test_registration.py
+++ b/accounts/tests/test_registration.py
@@ -156,7 +156,7 @@ class RegistrationTest(TestCase):
             'phone': 'test-phone',
             'has_ticket': True,
         })
-        self.assertContains(response, '', status_code=status.HTTP_302_FOUND)
+        self.assertRedirects(response, reverse('shifts'))
 
         self.assertTrue(User.objects.filter(email=email).exists())
 

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -66,7 +66,7 @@ class RegisterConfirmView(CreateView):
         return kwargs
 
     def form_valid(self, form):
-        form.instance.email = self.email
+        form.instance.email = self.email.lower()
         password = form.cleaned_data['password1']
         form.save()
         # profile fields


### PR DESCRIPTION
### What is the problem / feature ?

Email addresses were not being normalized on registration.  
### How did it get fixed / implemented ?

Added a call to lowercase the email address on the way through the registration form.
### How can someone test / see it ?
- Register with an uppercased email address is now forced to lowercase.
- Added a migration to lowercase all email addresses as well as remove any users with duplicate accounts.

_Here is a cute baby animal picture for your troubles..._

![buisnesscorgi](https://cloud.githubusercontent.com/assets/824194/2650550/ef4da0e0-bf74-11e3-9f78-96b427bb7de9.jpg)
