### PR TITLE
add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+#Development
+
+To start developing on the Volunteer Database clone the repository:
+
+```bash
+$ git clone git@github.com/Apogaea/voldb.git
+```
+
+##Django Codebase
+
+- Follow [PEP8](http://www.python.org/dev/peps/pep-0008/).  Highly recommend
+  getting your editor setup to automatically indicate pep8 violations.
+- Include tests.  Not everything is testable or should be tested, but the
+  general rule is that all new code should include tests.
+
+
+#Pull Requests
+
+It's a good idea to make pull requests early on.  A pull request represents the
+start of a discussion, and doesn't necessarily need to be the final, finished
+submission.
+
+It's also always best to make a new branch before starting work on a pull
+request.  This means that you'll be able to later switch back to working on
+another seperate issue without interfering with an ongoing pull requests.
+
+It's also useful to remember that if you have an outstanding pull request then
+pushing new commits to your GitHub repo will also automatically update the pull
+requests.
+
+GitHub's documentation for working on pull requests is [available here][pull-requests].
+
+Always run the tests before submitting pull requests, and ideally run `tox` in
+order to check that your modifications don't break anything.
+
+Once you've made a pull request take a look at the travis build status in the
+GitHub interface and make sure the tests are runnning as you'd expect.
+
+#Documentation
+
+> TODO: once the documentation branch and readthedocs builds are up.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![Build Status](https://travis-ci.org/Apogaea/voldb.png)](https://travis-ci.org/Apogaea/voldb)
 
+### Contributing
+
+See the [Contribution Guide](CONTRIBUTING.md)
+
 ### Development Environment Setup
 
 This is assuming a MacOS X or Linux development environment, with Python 2.7 installed.


### PR DESCRIPTION
### What is the problem / feature ?

No documented contribution guidelines
### How did it get fixed / implemented ?

Added a `CONTRIBUTING.md` so that github will pick it up as [contribution guidelines](https://github.com/blog/1184-contributing-guidelines)
### How can someone test / see it ?

See that when you open a pull request, it displays a header showing you contribution guidlines.

_Here is a cute animal picture for your troubles..._

![turtle3](https://cloud.githubusercontent.com/assets/824194/4509224/549e79c2-4b1d-11e4-9a2a-282b40af4997.jpg)
