### PR TITLE
Add django-dotenv requirement

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ tox==1.8.0
 pytest==2.6.3
 pytest-django==2.7.0
 pytest-xdist==1.11
+django-dotenv==1.2


### PR DESCRIPTION
### What is the problem / feature ?

The `managy.py` script needs `django-dotenv` to load the environment variables from `.env_defaults`, but that requirement isn't in the `requirements-dev.txt` file
### How did it get fixed / implemented ?

Added it to the `requirements-dev.txt` file
### How can someone test / see it ?

``` bash
pip install -r requirements-dev.txt
```

_Here is a cute animal picture for your troubles..._

![article-0-08525bca000005dc-462_634x397](https://cloud.githubusercontent.com/assets/824194/4553435/73e25536-4e99-11e4-8dff-7c19736efec7.jpg)
