### PR TITLE
use requirements-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This will use virtualenv to manage a Django v1.7 project.
 4. **Install application dependencies**
   
   ```bash
-  $ pip install -r requirements.txt
+  $ pip install -r requirements-dev.txt
   ```
 
 5. **Setup your database**


### PR DESCRIPTION
### What is the problem / feature ?

The readme didn't say to use `pip install -r requirements-dev.txt`
### How did it get fixed / implemented ?

Changed it to use `requirements-dev.txt`
### How can someone test / see it ?

Look at the readme

_Here is a cute animal picture for your troubles..._

![tumblr_m2nlww70jp1qe0inco1_500](https://cloud.githubusercontent.com/assets/824194/4553788/9b2f7aae-4ea0-11e4-8e66-288fd12c66fa.jpg)
