### PR TITLE
move requirement

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@ django-webtest==1.7.7
 factory-boy==2.4.1
 mock==1.0.1
 pytest-django==2.7.0
-python-dotenv==0.1.0
 pytest-xdist==1.11
 pytest==2.6.4
 tox==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,6 @@ ipython==1.2.1
 newrelic==2.18.1.15
 psycopg2==2.5.4
 pylibmc==1.4.1
+python-dotenv==0.1.0
 pytz==2014.10
 raven==5.1.1


### PR DESCRIPTION
Move the `python-dotenv` requirement to the main `requirements.txt` file.