### PR TITLE
Keep the shift grid in sync with the users shifts

### DIFF
--- a/js_tests/spec/javascripts/Shift_claimSlotSuccess_spec.js
+++ b/js_tests/spec/javascripts/Shift_claimSlotSuccess_spec.js
@@ -1,4 +1,11 @@
 describe("Shift.claimSlotSuccess", function() {
+  beforeAll(function() {
+      window.django_user = new Backbone.Model({id: 1, display_name: "test user", shifts: []});
+  });
+
+  afterAll(function() {
+      delete window.django_user;
+  });
   it("should be create a new Slot model and add it to the collection.", function() {
     var shift = new app.Shift({id: 3, claimed_slots: []});
     expect(shift.get("claimed_slots").length).toEqual(0);

--- a/volunteer/static/js/shift-grid/app.js
+++ b/volunteer/static/js/shift-grid/app.js
@@ -30,6 +30,7 @@ $(function(){
                 model: cellView.model,
                 collection: cellView.model.get("roles"),
             });
+            cellView.listenToOnce(cellModal, "dismiss", cellView.render);
             this.shiftLayout.cell_modal.show(cellModal);
             cellModal.$el.modal("show");
         },

--- a/volunteer/static/js/shift-grid/collections.js
+++ b/volunteer/static/js/shift-grid/collections.js
@@ -5,12 +5,26 @@ $(function(){
 
     var Roles = Backbone.Collection.extend({
         model: app.Role,
-        url: "/api/v2/roles/"
+        url: "/api/v2/roles/",
+        allShiftsHydrated: function() {
+            if ( this.length === 0 ) {
+                return false;
+            } else {
+                return this.all(function(role) {
+                    return role.get("shifts").isHydrated();
+                });
+            }
+        }
     });
 
     var Shifts = Backbone.Collection.extend({
         model: app.Shift,
-        url: "/api/v2/roles/"
+        url: "/api/v2/roles/",
+        isHydrated: function() {
+            return this.all(function(shift) {
+                return shift.isHydrated();
+            });
+        }
     });
 
     var Slots = Backbone.Collection.extend({

--- a/volunteer/static/js/shift-grid/models.js
+++ b/volunteer/static/js/shift-grid/models.js
@@ -194,11 +194,11 @@ $(function(){
         },
         openSlotCount: function() {
             if ( this.get("roles").allShiftsHydrated() ) {
-                return arst = _.chain(this.get("roles").pluck("shifts"))
+                return _.chain(this.get("roles").pluck("shifts"))
                     .map(function(s) { return s.pluck("open_slot_count"); })
                     .map(function(counts) { return _.reduce(counts, function(a, b) { return a + b;});})
                     .reduce(function(a, b) { return a + b; })
-                    .value()
+                    .value();
             } else {
                 return this.get("open_slot_count");
             }

--- a/volunteer/static/js/shift-grid/models.js
+++ b/volunteer/static/js/shift-grid/models.js
@@ -58,6 +58,10 @@ $(function(){
         claimSlotSuccess: function(slotData) {
             this.get("claimed_slots").add(slotData);
             this.set("claimErrors", []);
+            window.django_user.get("shifts").push(this.id);
+            // since we push the item onto the shifts array, we have to
+            // manually fire the change event.
+            window.django_user.trigger("change:shifts");
         },
         /*
          *  Template and View Helpers
@@ -155,7 +159,8 @@ $(function(){
             "cellTitleShort",
             "cellTitleLong",
             "pluralOpenSlots",
-            "hasUserShifts"
+            "hasUserShifts",
+            "openSlotCount"
         ],
         cellTitleShort: function() {
             var startAt = this.get("start_time");
@@ -177,7 +182,7 @@ $(function(){
             return this.cellTitleShort() + " " + startAt.format("dddd, MMMM Do YYYY");
         },
         pluralOpenSlots: function() {
-            return this.get("open_slot_count") > 1;
+            return this.openSlotCount() > 1;
         },
         hasUserShifts: function() {
             if ( this.get("is_empty") ) {
@@ -186,6 +191,17 @@ $(function(){
             var userShiftIds = window.django_user.get("shifts");
             var cellShiftIds = this.get("shifts").pluck("id");
             return !_.isEmpty(_.intersection(userShiftIds, cellShiftIds));
+        },
+        openSlotCount: function() {
+            if ( this.get("roles").allShiftsHydrated() ) {
+                return arst = _.chain(this.get("roles").pluck("shifts"))
+                    .map(function(s) { return s.pluck("open_slot_count"); })
+                    .map(function(counts) { return _.reduce(counts, function(a, b) { return a + b;});})
+                    .reduce(function(a, b) { return a + b; })
+                    .value()
+            } else {
+                return this.get("open_slot_count");
+            }
         }
     });
 

--- a/volunteer/static/js/shift-grid/templates/cell_modal_template.handlebars
+++ b/volunteer/static/js/shift-grid/templates/cell_modal_template.handlebars
@@ -1,7 +1,7 @@
 <div class="modal-dialog">
     <div class="modal-content">
         <div class="modal-header bg-primary">
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <button type="button" class="close dismiss" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
             <h4 class="modal-title">Shifts at {{ cellTitleLong }}</h4>
         </div>
         <div class="modal-body">
@@ -11,7 +11,7 @@
             </div>
         </div>
         <div class="modal-footer bg-primary">
-            <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            <button type="button" class="btn btn-default dismiss" data-dismiss="modal">Close</button>
         </div>
     </div>
 </div>

--- a/volunteer/static/js/shift-grid/templates/grid_cell_template.handlebars
+++ b/volunteer/static/js/shift-grid/templates/grid_cell_template.handlebars
@@ -12,8 +12,8 @@
         {{ cellTitleShort }}
     </div>
     <div class="panel-body">
-        {{#if open_slot_count }}
-            {{ open_slot_count }} open shift{{#if pluralOpenSlots }}s{{/if}}
+        {{#if openSlotCount }}
+            {{ openSlotCount }} open shift{{#if pluralOpenSlots }}s{{/if}}
         {{else}}
             Full
         {{/if}}

--- a/volunteer/static/js/shift-grid/views.js
+++ b/volunteer/static/js/shift-grid/views.js
@@ -63,6 +63,12 @@ $(function(){
         /*
          *  View for a single cell in the shift grid.
          */
+        initialize: function(options) {
+            this.listenTo(window.django_user, "change:shifts", this.render);
+        },
+        foo: function() {
+            debugger;
+        },
         tagName: "td",
         attributes: function() {
             var classes = ["panel", "panel-default"];
@@ -180,6 +186,10 @@ $(function(){
         },
         releaseSlotSuccess: function(model, response, options) {
             model.collection.remove(model);
+            window.django_user.set(
+                "shifts",
+                _.without(window.django_user.get("shifts"), this.model.get("shift"))
+            );
         }
     });
 
@@ -239,7 +249,11 @@ $(function(){
         childView: ModalRoleView,
         childViewContainer: ".roles",
         childCollectionProperty: "shifts",
-        template: Handlebars.templates.cell_modal_template
+        template: Handlebars.templates.cell_modal_template,
+        triggers: {
+            "click button.dismiss": "dismiss",
+            "click div.modal-backdrop": "dismiss"
+        }
     });
 
     app.GridPaginationView = GridPaginationView;

--- a/volunteer/static/js/shift-grid/views.js
+++ b/volunteer/static/js/shift-grid/views.js
@@ -66,9 +66,6 @@ $(function(){
         initialize: function(options) {
             this.listenTo(window.django_user, "change:shifts", this.render);
         },
-        foo: function() {
-            debugger;
-        },
         tagName: "td",
         attributes: function() {
             var classes = ["panel", "panel-default"];


### PR DESCRIPTION
When claiming and releasing shifts, the grid did not update correctly to show you how many slots were left and whether you had a shift in that slot.  This fixes that.