### PR TITLE
Register authtools views with underscore based names

### DIFF
--- a/volunteer/apps/accounts/urls.py
+++ b/volunteer/apps/accounts/urls.py
@@ -37,6 +37,10 @@ urlpatterns += patterns(
         name='password-reset-done',
     ),
     url(
+        r'^password-reset-done/$', 'password_reset_done',
+        name='password_reset_done',  # authtools uses underscore view names.
+    ),
+    url(
         r'^reset/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
         'password_reset_confirm_and_login',
         name='password-reset-confirm',
@@ -44,5 +48,9 @@ urlpatterns += patterns(
     url(
         r'^password-reset-complete/$', 'password_reset_complete',
         name='password-reset-complete',
+    ),
+    url(
+        r'^password-reset-complete/$', 'password_reset_complete',
+        name='password_reset_complete',  # authtools uses underscore view names.
     ),
 )

--- a/volunteer/settings.py
+++ b/volunteer/settings.py
@@ -38,7 +38,7 @@ TEMPLATE_DEBUG = DEBUG
 ALLOWED_HOSTS = excavator.env_list('DJANGO_ALLOWED_HOSTS', required=not DEBUG)
 
 # Application definition
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
@@ -65,7 +65,7 @@ INSTALLED_APPS = (
     'bootstrap3',
     'argonauts',
     'raven.contrib.django.raven_compat',
-)
+]
 
 if DEBUG:
     try:


### PR DESCRIPTION
Needed to register the authtools views with underscores in their view names as opposed to dashes.

https://app.getsentry.com/app24164288herokucom/production/group/60352846/