### PR TITLE
fixes #134 - shift modal doesn't dismiss on close buttons

### DIFF
--- a/volunteer/static/js/shift-grid/views.js
+++ b/volunteer/static/js/shift-grid/views.js
@@ -247,9 +247,11 @@ $(function(){
         childViewContainer: ".roles",
         childCollectionProperty: "shifts",
         template: Handlebars.templates.cell_modal_template,
-        triggers: {
-            "click button.dismiss": "dismiss",
-            "click div.modal-backdrop": "dismiss"
+        dismissModal: function(event) {
+            this.trigger("dismiss");
+        },
+        events: {
+            "click button.dismiss": "dismissModal",
         }
     });
 


### PR DESCRIPTION
Shift modal window doesn't close with close buttons.